### PR TITLE
added missing code required to compile on aarch64

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+The files
+
+	src/common/atomic.h 
+and 
+	src/common/RTMath.cpp
+
+contain code that is subject to GPLv2. This may be at odds with the 'commercial exception' policy in the linuxsampler altered GPL version. On the other hand, I'm quite positive that I'm not the first one to introduce GPLv2-licensed code to the codebase of linuxssampler (as atomic.h appears to already contain code from the linux kernel).

--- a/README-and-CHANGELOG-banana-pi-m5.md
+++ b/README-and-CHANGELOG-banana-pi-m5.md
@@ -1,7 +1,7 @@
 This is a rundown on the adjustments that I made in order to be able to compile linuxsampler on Debian 10 on an Banana Pi M5. You should consider the changes to be experimental, although my experience so far indicates that the resulting programm can be used as a MIDI-Piano in a stable manner.
 
 
-## Build and install on Debian 10
+# Build and install on Debian 10.13
 
 * Install all the required dependency libraries throught `apt`, make and install liblscp and libgig as found on [https://www.linuxsampler.org/downloads.html#linuxsampler](https://www.linuxsampler.org/downloads.html#linuxsampler). You probably need to install bison and flex just to make the linuxsampler compile.
 * On Debian 10, automake has a different version. It can be cured by running `aclocal` in the root folder.
@@ -9,6 +9,8 @@ This is a rundown on the adjustments that I made in order to be able to compile 
 * To build, run `AUTOMAKE=automake make`.
 * Optionally, run `sudo make install` (seems to recompile, though), or use it in place, for instance, via `sudo ln -s ./src/linuxsampler $HOME/bin`.
 * I use it with qsampler (which is available through apt) as frontend, the [Maestro Concert Grand v2](https://www.linuxsampler.org/instruments.html), a Focusrite Scarlet 4i4, an M-Audio Keystation 88 MK3 and qjackctl (also for patching) on a Banana Pi M5 which autostarts the sampler (no HIDs, no display, readonly mode).
+
+# Issues/Changelog
 
 ## Weird issue with yyprhs
 

--- a/README-and-CHANGELOG-banana-pi-m5.md
+++ b/README-and-CHANGELOG-banana-pi-m5.md
@@ -1,0 +1,25 @@
+This is a rundown on the adjustments that I made in order to be able to compile linuxsampler on Debian 10 on an Banana Pi M5. You should consider the changes to be experimental, although my experience so far indicates that the resulting programm can be used as a MIDI-Piano in a stable manner.
+
+
+## Build and install on Debian 10
+
+* Install all the required dependency libraries throught `apt`, make and install liblscp and libgig as found on [https://www.linuxsampler.org/downloads.html#linuxsampler](https://www.linuxsampler.org/downloads.html#linuxsampler). You probably need to install bison and flex just to make the linuxsampler compile.
+* On Debian 10, automake has a different version. It can be cured by running `aclocal` in the root folder.
+* To figure out missing dependencies, run `./configure` and read the output carefully.
+* To build, run `AUTOMAKE=automake make`.
+* Optionally, run `sudo make install` (seems to recompile, though), or use it in place, for instance, via `sudo ln -s ./src/linuxsampler $HOME/bin`.
+* I use it with qsampler (which is available through apt) as frontend, the [Maestro Concert Grand v2](https://www.linuxsampler.org/instruments.html), a Focusrite Scarlet 4i4, an M-Audio Keystation 88 MK3 and qjackctl (also for patching) on a Banana Pi M5 which autostarts the sampler (no HIDs, no display, readonly mode).
+
+## Weird issue with yyprhs
+
+* Install bison on the system and reconfigure, then the error about `yyprhs` goes away. No changes to the code needed.
+
+## atomic.h fixed
+
+* I've added code from linux kernel source v4.1 for arm64 to `src/common/atomic.h`. This routines seem to be used by the virtual midi driver.
+
+
+## rdtsc fix in RTMath.cpp
+
+* Found solution to problem on [stack overflow](https://stackoverflow.com/questions/40454157/is-there-an-equivalent-instruction-to-rdtsc-in-arm), added arch64 code from there. The code has probably been taken from the kernel source as well.
+

--- a/src/common/RTMath.cpp
+++ b/src/common/RTMath.cpp
@@ -73,6 +73,25 @@ RTMathBase::time_stamp_t RTMathBase::CreateTimeStamp() {
     return t;
     #elif defined(__APPLE__)
     return (time_stamp_t) mach_absolute_time();
+    /* This code is taken from stackoverflow, it's original source is probably some 
+     * linux kernel code and very likely to be GPLv2 code.
+     *
+     * 	https://stackoverflow.com/questions/40454157/is-there-an-equivalent-instruction-to-rdtsc-in-arm
+     */
+    #elif defined(__aarch64__)
+    uint64_t val;
+
+    /*
+     * According to ARM DDI 0487F.c, from Armv8.0 to Armv8.5 inclusive, the
+     * system counter is at least 56 bits wide; from Armv8.6, the counter
+     * must be 64 bits wide.  So the system counter could be less than 64
+     * bits wide and it is attributed with the flag 'cap_user_time_short'
+     * is true.
+     */
+    asm volatile("mrs %0, cntvct_el0" : "=r" (val));
+
+    return val;
+    /* End of the stackoverflow section */
     #else // we don't want to use a slow generic solution
     #  error "Sorry, LinuxSampler lacks time stamp code for your system."
     #  error "Please report this error and the CPU you are using to the LinuxSampler developers mailing list!"

--- a/src/common/atomic.h
+++ b/src/common/atomic.h
@@ -1240,6 +1240,141 @@ static __inline__ int atomic_inc_and_test(atomic_t *v)
 #  endif /* i386 */
 #  endif /* ppc */
 
+#if defined(__aarch64__)
+
+/*
+ * Based on arch/arm/include/asm/atomic.h
+ *
+ * Copyright (C) 1996 Russell King.
+ * Copyright (C) 2002 Deep Blue Solutions Ltd.
+ * Copyright (C) 2012 ARM Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define smp_mb()	asm volatile("dmb ish" : : : "memory")
+
+#define ACCESS_ONCE(x) (*(volatile typeof(x) *)&(x))
+#define ATOMIC_INIT(i)	{ (i) }
+
+/*
+ * On ARM, ordinary assignment (str instruction) doesn't clear the local
+ * strex/ldrex monitor on some implementations. The reason we can use it for
+ * atomic_set() is the clrex or dummy strex done on every exception return.
+ */
+#define atomic_read(v)	ACCESS_ONCE((v)->counter)
+#define atomic_set(v,i)	(((v)->counter) = (i))
+
+/*
+ * AArch64 UP and SMP safe atomic ops.  We use load exclusive and
+ * store exclusive to ensure that these are atomic.  We may loop
+ * to ensure that the update happens.
+ */
+
+#define ATOMIC_OP(op, asm_op)						\
+static inline void atomic_##op(int i, atomic_t *v)			\
+{									\
+	unsigned long tmp;						\
+	int result;							\
+									\
+	asm volatile("// atomic_" #op "\n"				\
+"1:	ldxr	%w0, %2\n"						\
+"	" #asm_op "	%w0, %w0, %w3\n"				\
+"	stxr	%w1, %w0, %2\n"						\
+"	cbnz	%w1, 1b"						\
+	: "=&r" (result), "=&r" (tmp), "+Q" (v->counter)		\
+	: "Ir" (i));							\
+}									\
+
+#define ATOMIC_OP_RETURN(op, asm_op)					\
+static inline int atomic_##op##_return(int i, atomic_t *v)		\
+{									\
+	unsigned long tmp;						\
+	int result;							\
+									\
+	asm volatile("// atomic_" #op "_return\n"			\
+"1:	ldxr	%w0, %2\n"						\
+"	" #asm_op "	%w0, %w0, %w3\n"				\
+"	stlxr	%w1, %w0, %2\n"						\
+"	cbnz	%w1, 1b"						\
+	: "=&r" (result), "=&r" (tmp), "+Q" (v->counter)		\
+	: "Ir" (i)							\
+	: "memory");							\
+									\
+	smp_mb();							\
+	return result;							\
+}
+
+#define ATOMIC_OPS(op, asm_op)						\
+	ATOMIC_OP(op, asm_op)						\
+	ATOMIC_OP_RETURN(op, asm_op)
+
+ATOMIC_OPS(add, add)
+ATOMIC_OPS(sub, sub)
+
+#undef ATOMIC_OPS
+#undef ATOMIC_OP_RETURN
+#undef ATOMIC_OP
+
+static inline int atomic_cmpxchg(atomic_t *ptr, int old, int new_)
+{
+	unsigned long tmp;
+	int oldval;
+
+	smp_mb();
+
+	asm volatile("// atomic_cmpxchg\n"
+"1:	ldxr	%w1, %2\n"
+"	cmp	%w1, %w3\n"
+"	b.ne	2f\n"
+"	stxr	%w0, %w4, %2\n"
+"	cbnz	%w0, 1b\n"
+"2:"
+	: "=&r" (tmp), "=&r" (oldval), "+Q" (ptr->counter)
+	: "Ir" (old), "r" (new_)
+	: "cc");
+
+	smp_mb();
+	return oldval;
+}
+
+#define atomic_xchg(v, new) (xchg(&((v)->counter), new))
+
+static inline int __atomic_add_unless(atomic_t *v, int a, int u)
+{
+	int c, old;
+
+	c = atomic_read(v);
+	while (c != u && (old = atomic_cmpxchg((v), c, c + a)) != c)
+		c = old;
+	return c;
+}
+
+#define atomic_inc(v)		atomic_add(1, v)
+#define atomic_dec(v)		atomic_sub(1, v)
+
+#define atomic_inc_and_test(v)	(atomic_add_return(1, v) == 0)
+#define atomic_dec_and_test(v)	(atomic_sub_return(1, v) == 0)
+#define atomic_inc_return(v)    (atomic_add_return(1, v))
+#define atomic_dec_return(v)    (atomic_sub_return(1, v))
+#define atomic_sub_and_test(i, v) (atomic_sub_return(i, v) == 0)
+
+#define atomic_add_negative(i,v) (atomic_add_return(i, v) < 0)
+
+
+#endif
+/* END OF CODE TAKEN FROM linux kernel sources (GPL v2) */
+
 /***********************************************************************/
 
 #else   /* !linux */


### PR DESCRIPTION
now builds and runs fine on banana pi M5, but should also work for all the other aarch64-*-pi devices out there.